### PR TITLE
Mb endpoints

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::InvoicesController < ApplicationController
+end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,2 +1,9 @@
 class Api::V1::InvoicesController < ApplicationController
+  def index
+    status = params[:status] #grabs the value of the status query parameter - shipped, packaged, returned
+    merchant = Merchant.find(params[:merchant_id]) #looks up merchant with given merchant id frome the URL
+    invoices = merchant.invoices.where(status: status) #this will get all the merchants invoices that match the status being passed in
+
+    render json: InvoiceSerializer.new(invoices)
+  end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,3 +1,7 @@
 class Api::V1::ItemsController < ApplicationController
-  
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    head :no_content
+  end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -6,16 +6,20 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def destroy
-    merchant = Merhcant.find_by(id: params[:id])
-    
-    if merchant
+    # begin
+      merchant = Merchant.find(params[:id])
       merchant.destroy
       head :no_content
-    else 
-      render json: {
-        message: "Unable to delete merchant",
-        errors: ["Merchant ID #{params[:id]} is invalid"],
-      }, status: :not_found
+    # rescue ActiveRecord::RecordNotFound => error
+    #   render json: {
+    #     "errors": [
+    #       {
+    #       status: "404",
+    #       message: [error.message]
+    #       }
+    #     ]
+    #   }, status: :not_found
+    # end
   end 
 end
 

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -6,6 +6,9 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def destroy
+    merchant = Merhcant.find(param[:id])
+    merchant.destroy
+    head :no_content
   end 
 end
 

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -4,5 +4,8 @@ class Api::V1::MerchantsController < ApplicationController
     merchant = Merchant.all
     render json: MerchantSerializer.new(merchant)
   end
+
+  def destroy
+  end 
 end
 

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -6,9 +6,16 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def destroy
-    merchant = Merhcant.find(param[:id])
-    merchant.destroy
-    head :no_content
+    merchant = Merhcant.find_by(id: params[:id])
+    
+    if merchant
+      merchant.destroy
+      head :no_content
+    else 
+      render json: {
+        message: "Unable to delete merchant",
+        errors: ["Merchant ID #{params[:id]} is invalid"],
+      }, status: :not_found
   end 
 end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,6 @@
 class Invoice < ApplicationRecord
   belongs_to :customer
   belongs_to :merchant
-  has_many :invoice_items
-  has_many :transactions
+  has_many :invoice_items, dependent: :destroy
+  has_many :transactions, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,4 @@
 class Item < ApplicationRecord
   belongs_to :merchant
-  has_many :invoice_items
+  has_many :invoice_items, dependent: :destroy
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,4 @@
 class Merchant < ApplicationRecord
-  has_many :items
-  has_many :invoices
+  has_many :items, dependent: :destroy
+  has_many :invoices, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   get "/api/v1/merchants", to: "api/v1/merchants#index"
-  delete "/api/v1/merchant/:id", to: "api/v1/merchant#destroy"
+  delete "/api/v1/merchants/:id", to: "api/v1/merchants#destroy"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,7 @@ Rails.application.routes.draw do
   get "/api/v1/merchants", to: "api/v1/merchants#index"
   delete "/api/v1/merchants/:id", to: "api/v1/merchants#destroy"
   delete "/api/v1/items/:id", to: "api/v1/items#destroy"
+
+  get "/api/v1/merchants/:merchant_id/invoices", to: "api/v1/invoices#index"
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   get "/api/v1/merchants", to: "api/v1/merchants#index"
+  delete "/api/v1/merchant/:id", to: "api/v1/merchant#destroy"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   # root "posts#index"
   get "/api/v1/merchants", to: "api/v1/merchants#index"
   delete "/api/v1/merchants/:id", to: "api/v1/merchants#destroy"
+  delete "/api/v1/items/:id", to: "api/v1/items#destroy"
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,6 +3,21 @@ require "spec_helper"
 
 RSpec.describe Item, type: :model do
   it { should belong_to :merchant }
-  it { should have_many :invoice_items }
+  it { should have_many(:invoice_items).dependent(:destroy) }
 
+  describe 'dependent destroy' do
+    it 'destroys associated invoice_items when item is deleted' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      item = merchant.items.create!(name: "Test Item", description: "Desc", unit_price: 50)
+      customer = Customer.create!(first_name: "John", last_name: "Doe")
+      invoice = Invoice.create!(status: "shipped", merchant_id: merchant.id, customer_id: customer.id)
+      item.invoice_items.create!(invoice_id: invoice.id, quantity: 1, unit_price: 50)
+
+      initial_invoice_item_count = InvoiceItem.count
+      merchant.destroy
+      final_invoice_item_count = InvoiceItem.count
+
+      expect(final_invoice_item_count).to eq(initial_invoice_item_count -1)
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -2,7 +2,56 @@ require "rails_helper"
 require "spec_helper"
 
 RSpec.describe Merchant, type: :model do
-  it { should have_many :items }
-  it { should have_many :invoices }
+  it { should have_many(:items).dependent(:destroy) }
+  it { should have_many(:invoices).dependent(:destroy) }
 
+  describe 'dependent destroy' do
+    it 'destroys associated items when merchant is deleted' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      merchant.items.create!(name: "Item 1", description: "Desc", unit_price: 100)
+      merchant.items.create!(name: "Item 2", description: "Desc", unit_price: 200)
+
+      initial_item_count = Item.count
+      merchant.destroy
+      final_item_count = Item.count
+
+      expect(final_item_count).to eq(initial_item_count -2)
+    end
+
+    it 'destroys associated invoices when merchant is deleted' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      customer = Customer.create!(first_name: "Jane", last_name: "Doe")
+      merchant.invoices.create!(status: "shipped", customer_id: customer.id)
+
+      initial_invoice_count = Invoice.count
+      merchant.destroy
+      final_invoice_count = Invoice.count
+      expect(final_invoice_count).to eq(initial_invoice_count -1)
+    end
+
+    it 'destroys associated invoice_items when merchant is deleted' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      item = merchant.items.create!(name: "Test Item", description: "Desc", unit_price: 50)
+      customer = Customer.create!(first_name: "John", last_name: "Smith")
+      invoice = merchant.invoices.create!(status: "shipped", customer_id: customer.id)
+      item.invoice_items.create!(invoice_id: invoice.id, quantity: 5, unit_price: 50)
+
+      initial_invoice_item_count = InvoiceItem.count
+      merchant.destroy
+      final_invoice_item_count = InvoiceItem.count
+      expect(final_invoice_item_count).to eq(initial_invoice_item_count -1)
+    end
+
+    it 'destroys associated transactions when merchant is deleted' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      customer = Customer.create!(first_name: "Sam", last_name: "Doe")
+      invoice = merchant.invoices.create!(status: "shipped", customer_id: customer.id)
+      invoice.transactions.create!(credit_card_number: "1234567890123456", result: "success")
+
+      initial_transaction_count = Transaction.count
+      merchant.destroy
+      final_transaction_count = Transaction.count
+      expect(final_transaction_count).to eq(initial_transaction_count -1)
+    end
+  end
 end

--- a/spec/requests/invoice_request_spec.rb
+++ b/spec/requests/invoice_request_spec.rb
@@ -32,18 +32,5 @@ RSpec.describe "Invoice endpoints", type: :request do
       data = JSON.parse(response.body, symbolize_names: true)[:data]
       expect(data).to eq([])
     end
-
-    xit 'returns a not_found error' do
-      delete "/api/v1/merchants/99999"
-
-      expect(response).to have_http_status(:not_found)
-
-      parsed_json = JSON.parse(response.body, symbolize_names: true)
-      errors = parsed_json[:errors].first
-
-      expect(parsed_json[:errors]).to be_an(Array)
-      expect(errors[:status]).to eq("404")
-      expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
-    end
   end
 end

--- a/spec/requests/invoice_request_spec.rb
+++ b/spec/requests/invoice_request_spec.rb
@@ -32,5 +32,34 @@ RSpec.describe "Invoice endpoints", type: :request do
       data = JSON.parse(response.body, symbolize_names: true)[:data]
       expect(data).to eq([])
     end
+
+    xit 'returns a bad_request error for invalid status query' do
+      merchant = Merchant.create!(name: "Test Merchant")
+
+      get "/api/v1/merchants/#{merchant.id}/invoices?status=invalid_status"
+
+      expect(response).to have_http_status(:bad_request)
+
+      parsed_json = JSON.parse(response.body, symbolize_names: true)
+      errors = parsed_json[:errors]
+
+      expect(errors).to be_an(Array)
+      expect(errors[:status]).to eq("400")
+      expect(parsed_json[:message]).to eq("your query could not be completed")
+      expect(errors).to include("Invalid status. Must be one of: shipped, returned, packaged")
+    end
+
+    xit 'returns a not_found error if merchant does not exist' do
+      get "/api/v1/merchants/999999/invoices?status=shipped"
+
+      expect(response).to have_http_status(:not_found)
+
+      parsed_json = JSON.parse(response.body, symbolize_names: true)
+      errors = parsed_json[:errors].first
+
+      expect(parsed_json[:errors]).to be_an(Array)
+      expect(errors[:status]).to eq("404")
+      expect(errors[:message]).to include("Couldn't find Merchant with 'id'=999999")
+    end
   end
 end

--- a/spec/requests/invoice_request_spec.rb
+++ b/spec/requests/invoice_request_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Invoice endpoints", type: :request do
+  describe 'index' do
+    it 'it returns all invoices for given merchant by its status' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      customer = Customer.create!(first_name: "Lulu", last_name: "Customer")
+      shipped_invoice = Invoice.create!(status: "shipped", customer_id: customer.id, merchant_id: merchant.id)
+      packaged_invoice = Invoice.create!(status: "packaged", customer_id: customer.id, merchant_id: merchant.id)
+
+      get "/api/v1/merchants/#{merchant.id}/invoices?status=shipped"
+
+      expect(response).to be_successful
+
+      data = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(data.count).to eq(1)
+      expect(data.first[:id]).to eq(shipped_invoice.id.to_s)
+      expect(data.first[:attributes][:status]).to eq("shipped")
+    end
+
+    it 'returns an empty array if no invoices match the given status' do 
+      merchant = Merchant.create!(name: "Test Merchant")
+      customer = Customer.create!(first_name: "Lulu", last_name: "Customer")
+      shipped_invoice = Invoice.create!(status: "shipped", customer_id: customer.id, merchant_id: merchant.id)
+      packaged_invoice = Invoice.create!(status: "packaged", customer_id: customer.id, merchant_id: merchant.id)
+
+      get "/api/v1/merchants/#{merchant.id}/invoices?status=returned"
+
+      expect(response).to be_successful
+      
+      data = JSON.parse(response.body, symbolize_names: true)[:data]
+      expect(data).to eq([])
+    end
+  end
+end

--- a/spec/requests/invoice_request_spec.rb
+++ b/spec/requests/invoice_request_spec.rb
@@ -32,5 +32,18 @@ RSpec.describe "Invoice endpoints", type: :request do
       data = JSON.parse(response.body, symbolize_names: true)[:data]
       expect(data).to eq([])
     end
+
+    xit 'returns a not_found error' do
+      delete "/api/v1/merchants/99999"
+
+      expect(response).to have_http_status(:not_found)
+
+      parsed_json = JSON.parse(response.body, symbolize_names: true)
+      errors = parsed_json[:errors].first
+
+      expect(parsed_json[:errors]).to be_an(Array)
+      expect(errors[:status]).to eq("404")
+      expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
+    end
   end
 end

--- a/spec/requests/item_request_spec.rb
+++ b/spec/requests/item_request_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Item endpoints", type: :request do
       parsed_json = JSON.parse(response.body, symbolize_names: true)
       errors = parsed_json[:errors].first
 
+      expect(parsed_json[:errors]).to be_an(Array)
       expect(errors[:status]).to eq("404")
       expect(errors[:message]).to include("Couldn't find Item with 'id'=99999")
     end

--- a/spec/requests/item_request_spec.rb
+++ b/spec/requests/item_request_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Item endpoints", type: :request do
+  describe 'destroy a item' do
+    it 'deletes a item and returns not content' do
+      merchant = Merchant.create!(name: "Test Merchant")
+      item = merchant.items.create!(name: "Test Item", description: "Born to be deleted", unit_price: 10)
+
+      delete "/api/v1/items/#{item.id}"
+
+      expect(response).to have_http_status(:no_content)
+      expect(Item.find_by(id: item.id)).to be_nil
+    end
+
+    # it 'returns a not_found error' do
+    #   delete "/api/v1/items/99999"
+
+    #   expect(response).to have_http_status(:not_found)
+
+    #   parsed_json = JSON.parse(response.body, symbolize_names: true)
+    #   errors = parsed_json[:errors].first
+
+    #   expect(errors[:status]).to eq("404")
+    #   expect(errors[:message]).to include("Couldn't find Item with 'id'=99999")
+    # end
+
+    it 'also deletes associated items and accosiated invoice item when merchant is deleted' do 
+      merchant = Merchant.create!(name: "Survivor Merchant")
+     
+      item = merchant.items.create!(name: "Cascading Test Item", description: "Born to be deleted", unit_price: 10)
+      customer = Customer.create!(first_name: "Lulu", last_name: "Customer")
+      invoice = Invoice.create!(status: "shipped", customer_id: customer.id, merchant_id: merchant.id)
+      invoice_item = item.invoice_items.create!(invoice: invoice, quantity: 5, unit_price: 100)
+
+      initial_item_count = Item.count
+      initial_invoice_item_count = InvoiceItem.count
+      expect(Merchant.count).to eq(1)
+      
+      delete "/api/v1/items/#{item.id}"
+      
+      final_invoice_item_count = InvoiceItem.count
+      final_item_count = Item.count
+
+      expect(final_item_count).to eq(initial_item_count - 1)
+      expect(final_invoice_item_count).to eq(initial_invoice_item_count - 1)
+      expect(Merchant.count).to eq(1)
+    end
+  end
+end

--- a/spec/requests/item_request_spec.rb
+++ b/spec/requests/item_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Item endpoints", type: :request do
-  describe 'destroy a item' do
+  describe 'destroy' do
     it 'deletes a item and returns not content' do
       merchant = Merchant.create!(name: "Test Merchant")
       item = merchant.items.create!(name: "Test Item", description: "Born to be deleted", unit_price: 10)

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Merchant endpoints", type: :request do
-  describe 'destroy a merchant' do
+  describe 'destroy' do
     it 'deletes a merchant and returns not content' do
       merchant = Merchant.create!(name: "Test Merchant")
 

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -1,0 +1,3 @@
+require "rails_helper"
+
+RSpec.describe "Merchant endpoints", type: :request do

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -23,17 +23,23 @@ RSpec.describe "Merchant endpoints", type: :request do
     #   expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
     # end
 
-    it 'also deletes associated items when merchant is deleted' do 
+    it 'also deletes associated items and accosiated invoice item when merchant is deleted' do 
       merchant = Merchant.create!(name: "Test Cascading")
      
       item1 = merchant.items.create!(name: "Item 1", description: "Born to be deleted", unit_price: 10)
       item2 = merchant.items.create!(name: "Item 2", description: "Second born to be deleted", unit_price: 20)
+      customer = Customer.create!(first_name: "Test", last_name: "Customer")
+      invoice = Invoice.create!(status: "shipped", customer_id: customer.id, merchant_id: merchant.id)
+      invoice_item = item1.invoice_items.create!(invoice: invoice, quantity: 5, unit_price: 100)
 
-      intial_item_count = Item.count 
+      initial_item_count = Item.count
+      initial_invoice_item_count = InvoiceItem.count 
       delete "/api/v1/merchants/#{merchant.id}"
       final_item_count = Item.count 
-    
-      expect(final_item_count).to eq(intial_item_count - 2)
+      final_invoice_item_count = InvoiceItem.count
+
+      expect(final_item_count).to eq(initial_item_count - 2)
+      expect(final_invoice_item_count).to eq(initial_invoice_item_count - 1)
     end
   end
 end

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -1,3 +1,39 @@
 require "rails_helper"
 
 RSpec.describe "Merchant endpoints", type: :request do
+  describe 'destroy a merchant' do
+    it 'deletes a merchant and returns not content' do
+      merchant = Merchant.create!(name: "Test Merchant")
+
+      delete "/api/v1/merchants/#{merchant.id}"
+
+      expect(response).to have_http_status(:no_content)
+      expect(Merchant.find_by(id: merchant.id)).to be_nil
+    end
+
+    # it 'returns a not_found error' do
+    #   delete "/api/v1/merchants/99999"
+
+    #   expect(response).to have_http_status(:not_found)
+
+    #   parsed_json = JSON.parse(response.body, symbolize_names: true)
+    #   errors = parsed_json[:errors].first
+
+    #   expect(errors[:status]).to eq("404")
+    #   expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
+    # end
+
+    it 'also deletes associated items when merchant is deleted' do 
+      merchant = Merchant.create!(name: "Test Cascading")
+     
+      item1 = merchant.items.create!(name: "Item 1", description: "Born to be deleted", unit_price: 10)
+      item2 = merchant.items.create!(name: "Item 2", description: "Second born to be deleted", unit_price: 20)
+
+      intial_item_count = Item.count 
+      delete "/api/v1/merchants/#{merchant.id}"
+      final_item_count = Item.count 
+    
+      expect(final_item_count).to eq(intial_item_count - 2)
+    end
+  end
+end

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe "Merchant endpoints", type: :request do
       expect(Merchant.find_by(id: merchant.id)).to be_nil
     end
 
-    # it 'returns a not_found error' do
-    #   delete "/api/v1/merchants/99999"
+    xit 'returns a not_found error' do
+      delete "/api/v1/merchants/99999"
 
-    #   expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:not_found)
 
-    #   parsed_json = JSON.parse(response.body, symbolize_names: true)
-    #   errors = parsed_json[:errors].first
+      parsed_json = JSON.parse(response.body, symbolize_names: true)
+      errors = parsed_json[:errors].first
 
-    #   expect(parsed_json[:errors]).to be_an(Array)
-    #   expect(errors[:status]).to eq("404")
-    #   expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
-    # end
+      expect(parsed_json[:errors]).to be_an(Array)
+      expect(errors[:status]).to eq("404")
+      expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
+    end
 
-    it 'also deletes associated items and accosiated invoice item when merchant is deleted' do 
+    it 'also deletes associated items and accosiated invoice item when merchant is deleted' do
       merchant = Merchant.create!(name: "Test Cascading")
      
       item1 = merchant.items.create!(name: "Item 1", description: "Born to be deleted", unit_price: 10)
@@ -32,15 +32,24 @@ RSpec.describe "Merchant endpoints", type: :request do
       customer = Customer.create!(first_name: "Test", last_name: "Customer")
       invoice = Invoice.create!(status: "shipped", customer_id: customer.id, merchant_id: merchant.id)
       invoice_item = item1.invoice_items.create!(invoice: invoice, quantity: 5, unit_price: 100)
+      transaction = invoice.transactions.create!(credit_card_number: "1234567890123456", result: "success")
 
-      initial_item_count = Item.count
-      initial_invoice_item_count = InvoiceItem.count 
+      expect(Merchant.find_by(id: merchant.id)).to_not be_nil
+      expect(Invoice.find_by(id: invoice.id)).to_not be_nil
+      expect(Transaction.find_by(id: transaction.id)).to_not be_nil
+      expect(InvoiceItem.find_by(id: invoice_item.id)).to_not be_nil
+      expect(Item.find_by(id: item1.id)).to_not be_nil
+      expect(Item.find_by(id: item2.id)).to_not be_nil
+
       delete "/api/v1/merchants/#{merchant.id}"
-      final_item_count = Item.count 
-      final_invoice_item_count = InvoiceItem.count
 
-      expect(final_item_count).to eq(initial_item_count - 2)
-      expect(final_invoice_item_count).to eq(initial_invoice_item_count - 1)
+      expect(response).to have_http_status(:no_content)
+      expect(Merchant.find_by(id: merchant.id)).to be_nil
+      expect(Invoice.find_by(id: invoice.id)).to be_nil
+      expect(Transaction.find_by(id: transaction.id)).to be_nil
+      expect(Item.find_by(id: item1.id)).to be_nil
+      expect(Item.find_by(id: item2.id)).to be_nil
+      expect(InvoiceItem.find_by(id: invoice_item.id)).to be_nil
     end
   end
 end

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Merchant endpoints", type: :request do
     #   parsed_json = JSON.parse(response.body, symbolize_names: true)
     #   errors = parsed_json[:errors].first
 
+    #   expect(parsed_json[:errors]).to be_an(Array)
     #   expect(errors[:status]).to eq("404")
     #   expect(errors[:message]).to include("Couldn't find Merchant with 'id'=99999")
     # end


### PR DESCRIPTION
This PR adds the ability to:
- Delete a merchant (DELETE /api/v1/merchants/:id)
- Delete an item (DELETE /api/v1/items/:id)
- Get all invoices for a merchant by status (GET /api/v1/merchants/:merchant_id/invoices?status=shipped)

- When a merchant is deleted, all related items, invoice items, and transactions are also deleted.
- When an item is deleted, related invoice items are deleted.
- Added request/model tests for destroy and irequest tests for invoice index endpoints (happy and sad paths).